### PR TITLE
Added in a "failed" teleop placement field

### DIFF
--- a/2023/CU_config.js
+++ b/2023/CU_config.js
@@ -126,6 +126,18 @@ var config_data = `
 			"showUndo": "false",
 			"shape": "circle 12 black red true"
 		},
+        {
+            "name": "Failed placement",
+            "code": "fail",
+            "type": "clickable_image",
+            "filename": "2023/grid_image.png",
+            "dimensions": "9 4",
+            "clickRestriction": "onePerBox",
+            "toggleClick": "true",
+            "showFlip": "false",
+            "showUndo": "false",
+            "shape": "circle 12 black blue true"
+        },
 		{
 			"name": "Attempted to place<br>Cube/Cone but missed",
 			"code": "tfl",


### PR DESCRIPTION
Added in a secondary field on the teleop screen. On this screen, the second one in the list, students can record where bots tried to place an object but failed. It will be reported in the output data using the same format as "tsg" but coded as "fail"